### PR TITLE
fix(db_infinite_loop): Address instance wherein the db connection is …

### DIFF
--- a/lib/DBD/PgPP.pm
+++ b/lib/DBD/PgPP.pm
@@ -1084,6 +1084,9 @@ sub _if_short_then_add_buffer {
         my $packet = '';
         $handle->recv($packet, $BUFFER_LEN, 0);
         DBD::PgPP::Protocol::_dump_packet($packet);
+	if(0 == length($packet)) {
+	    Carp::croak("Connection to database disconnected\n");
+	}
         $self->{buffer} .= $packet;
     }
 }


### PR DESCRIPTION
…severed DBPgPP hangs indefintely

**Procedure to reproduce**

- Create a listening socket using nc (netcat)
- Connect to said port using DBD::PgPP
- Drop the connection

**Fix**

I use nc to create a listening socket and use DBD::PgPP to connect to that port during which I cancel the connection with ctrl-c and disconnect from nc (netcat). The tester script hangs and does not exit.

With the patch I am proposing it we get a stack trace when a disconnection occurs and it exits gracefully.

[tsaintvil]$ perl tester.pl
heyhey$VAR1 = sub { "DUMMY" };
DBI connect('dbname=test;host=127.0.0.1;port=543213','',...) failed: Connection to database disconnected
 at /lib/perl5/DBD/PgPP.pm line 1045.
 at /Redacted.pm line 436.



[tsaintvil@]$ nc -l 543213
 (testtsaintvil^C
[tsaintvil@]$


I am open to comments, concerns, and suggestions. (perhaps retry?)



